### PR TITLE
Created inventory and orders snapshots

### DIFF
--- a/snapshots/inventory_snapshot.sql
+++ b/snapshots/inventory_snapshot.sql
@@ -1,0 +1,15 @@
+{% snapshot inventory_snapshot %}
+
+{{
+    config(
+      target_schema='main',
+      unique_key='id',
+      strategy='timestamp',
+      updated_at='created_at'
+    )
+}}
+
+SELECT * 
+FROM {{ source('ecommerce', 'inventory_items') }}
+
+{% endsnapshot %}

--- a/snapshots/orders_snapshot.sql
+++ b/snapshots/orders_snapshot.sql
@@ -1,0 +1,15 @@
+{% snapshot orders_snapshot %}
+
+{{
+    config(
+      target_schema='main',
+      unique_key='order_id',
+      strategy='timestamp',
+      updated_at='created_at' 
+    )
+}}
+
+SELECT * 
+FROM {{ source('ecommerce', 'orders') }}
+
+{% endsnapshot %}


### PR DESCRIPTION
Two dbt snapshot models: orders_snapshot and inventory_snapshot.
Configured to capture daily changes with dbt_valid_from/dbt_valid_to intervals.
Snapshot configs added to dbt_project.yml.
Enables “time travel” queries on orders and inventory states.
Simplifies trend analysis without complex SQL in marts.